### PR TITLE
Removed hardcoded URL as part of removing dependency on Gerrit

### DIFF
--- a/jenkins/jobs/dsl/java_reference_application_jobs.groovy
+++ b/jenkins/jobs/dsl/java_reference_application_jobs.groovy
@@ -50,16 +50,7 @@ pipelineAppJob.with {
   triggers scmProvider.trigger(projectScmNamespace, referenceAppgitRepo, "master")
   definition {
     cpsScm {
-      scm {
-        git {
-          remote { 
-            url(referenceAppGitUrl) 
-            credentials("adop-jenkins-master")
-          }
-          branches('master')
-          scriptPath('Jenkinsfile')
-        }
-      }
+      scm scmProvider.get(projectScmNamespace, referenceAppGitUrl, "*/master", "adop-jenkins-master", 'Jenkinsfile')
     }
   }
 }


### PR DESCRIPTION
Removed dependency on Gerrit as part of migration to Gitlab